### PR TITLE
Change docset keyword to xep

### DIFF
--- a/XEPs.docset/Contents/Info.plist
+++ b/XEPs.docset/Contents/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleName</key>
 	<string>XEP Series</string>
 	<key>DocSetPlatformFamily</key>
-	<string>xmpp</string>
+	<string>xep</string>
 	<key>isDashDocset</key>
 	<true/>
 </dict>


### PR DESCRIPTION
Test-Information:

Works with Dash 2 on OS X 10.12